### PR TITLE
Fix error on InputStream conversion

### DIFF
--- a/examples/src/main/java/com/convertapi/examples/ConvertStream.java
+++ b/examples/src/main/java/com/convertapi/examples/ConvertStream.java
@@ -25,16 +25,16 @@ public class ConvertStream {
         Config.setDefaultApiCredentials(getenv("API_TOKEN"));   // Get your api token at https://www.convertapi.com/a/authentication
 
         // Creating file data stream
-        InputStream stream = Files.newInputStream(new File("src/main/resources/test.docx").toPath());
-
-        System.out.println("Converting stream of DOCX data to PDF");
-        CompletableFuture<ConversionResult> result = ConvertApi.convert("docx", "pdf",
+        try (InputStream stream = Files.newInputStream(new File("src/main/resources/test.docx").toPath())) {
+            System.out.println("Converting stream of DOCX data to PDF");
+            CompletableFuture<ConversionResult> result = ConvertApi.convert("docx", "pdf",
                 new Param("file", stream, "test.docx")
-        );
+            );
 
-        Path pdfFile = Paths.get(System.getProperty("java.io.tmpdir") + "/myfile.pdf");
-        result.get().saveFile(pdfFile).get();
+            Path pdfFile = Paths.get(System.getProperty("java.io.tmpdir") + "/myfile.pdf");
+            result.get().saveFile(pdfFile).get();
 
-        System.out.println("PDF file saved to: " + pdfFile.toString());
+            System.out.println("PDF file saved to: " + pdfFile.toString());
+        }
     }
 }

--- a/src/main/java/com/convertapi/client/RequestBodyStream.java
+++ b/src/main/java/com/convertapi/client/RequestBodyStream.java
@@ -20,15 +20,6 @@ class RequestBodyStream {
             }
 
             @Override
-            public long contentLength() {
-                try {
-                    return inputStream.available();
-                } catch (IOException e) {
-                    return 0;
-                }
-            }
-
-            @Override
             public void writeTo(BufferedSink sink) throws IOException {
                 Source source = null;
                 try {


### PR DESCRIPTION
- Remove `contentLength` from `RequestBodyStream` because it is impossible to reliably tell the size of the input steam
- Explicitly close the input stream in the example